### PR TITLE
Add Google Sign-In auth dependency

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(project.dependencies.platform("com.google.firebase:firebase-bom:33.16.0"))
             implementation("com.google.firebase:firebase-auth:22.3.1")
+            implementation("com.google.android.gms:play-services-auth:21.2.0")
             implementation("com.google.firebase:firebase-firestore:24.10.0")
             implementation("com.google.firebase:firebase-database-ktx")
             implementation("com.google.firebase:firebase-storage-ktx")


### PR DESCRIPTION
This PR fixes the build issue caused by the new Google Sign-In component.

Problem:
- GoogleSignInComponent.kt was using GoogleSignIn and GoogleSignInOptions.
- The project did not have the Google Play Services Auth dependency.
- This caused unresolved reference errors during build.

Fix:
- Added the missing Google Sign-In auth dependency in composeApp/build.gradle.kts.

Tested:
- Ran Gradle build successfully.
- Build result: BUILD SUCCESSFUL.